### PR TITLE
no pool fix

### DIFF
--- a/custom_components/scribe/writer.py
+++ b/custom_components/scribe/writer.py
@@ -951,6 +951,9 @@ class ScribeWriter:
         """Flush the queue to the database."""
         try:
             self._flush_pending = False  # Reset flag immediately
+
+            if not self._pool:
+                return
             
             # Prune history first (maintain rolling window even if idle)
             now = time.time()


### PR DESCRIPTION
T his fix this error I saw on my logs:

2026-04-05 05:38:55.608 WARNING (MainThread) [custom_components.scribe.writer] Buffering 1137 items due to failure. Current queue size: 0
2026-04-05 05:38:56.230 ERROR (MainThread) [custom_components.scribe.writer] Error flushing batch: 'NoneType' object has no attribute 'acquire'