### PR TITLE
Use COPY for batched state/event writes

### DIFF
--- a/custom_components/scribe/writer.py
+++ b/custom_components/scribe/writer.py
@@ -211,6 +211,23 @@ class ScribeWriter:
             async with conn.transaction():
                 await conn.executemany(sql, args_list)
 
+    async def _copy_records(self, conn: asyncpg.Connection, table_name: str, columns: list[str], records: list[tuple[Any, ...]]):
+        """Write batched records via PostgreSQL COPY, falling back to executemany if unavailable."""
+        if not records:
+            return
+
+        if hasattr(conn, "copy_records_to_table"):
+            await conn.copy_records_to_table(
+                table_name=table_name,
+                records=records,
+                columns=columns,
+            )
+            return
+
+        placeholders = ", ".join(f"${idx}" for idx in range(1, len(columns) + 1))
+        fallback_sql = f"INSERT INTO {table_name} ({', '.join(columns)}) VALUES ({placeholders})"
+        await conn.executemany(fallback_sql, records)
+
     async def _fetchval(self, sql: str, *args):
         """Fetch a single scalar value."""
         async with self._pool.acquire() as conn:
@@ -1025,14 +1042,24 @@ class ScribeWriter:
                 async with self._pool.acquire() as conn:
                     async with conn.transaction():
                         if states_data:
-                            await conn.executemany(
-                                "INSERT INTO states_raw (time, metadata_id, state, value, attributes) VALUES ($1, $2, $3, $4, $5::jsonb)",
-                                [(s['time'], s['metadata_id'], s.get('state'), s.get('value'), s.get('attributes')) for s in states_data]
+                            await self._copy_records(
+                                conn=conn,
+                                table_name="states_raw",
+                                columns=["time", "metadata_id", "state", "value", "attributes"],
+                                records=[
+                                    (s['time'], s['metadata_id'], s.get('state'), s.get('value'), s.get('attributes'))
+                                    for s in states_data
+                                ],
                             )
                         if events_data:
-                            await conn.executemany(
-                                f"INSERT INTO {self.table_name_events} (time, event_type, event_data, origin, context_id, context_user_id, context_parent_id) VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7)",
-                                [(e['time'], e['event_type'], e.get('event_data'), e.get('origin'), e.get('context_id'), e.get('context_user_id'), e.get('context_parent_id')) for e in events_data]
+                            await self._copy_records(
+                                conn=conn,
+                                table_name=self.table_name_events,
+                                columns=["time", "event_type", "event_data", "origin", "context_id", "context_user_id", "context_parent_id"],
+                                records=[
+                                    (e['time'], e['event_type'], e.get('event_data'), e.get('origin'), e.get('context_id'), e.get('context_user_id'), e.get('context_parent_id'))
+                                    for e in events_data
+                                ],
                             )
                 
                 duration = time.time() - start_time

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ def mock_db_connection():
     mock_conn = AsyncMock()
     mock_conn.execute = AsyncMock()
     mock_conn.executemany = AsyncMock()
+    mock_conn.copy_records_to_table = AsyncMock()
     mock_conn.fetchval = AsyncMock()
     mock_conn.fetchrow = AsyncMock()
     mock_conn.fetch = AsyncMock()

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -121,13 +121,41 @@ async def test_writer_enqueue_flush(writer, mock_db_connection):
     await asyncio.sleep(0.1)
     
     # If auto-flush worked, queue should be empty
-    # Verify DB calls
-    # We expect INSERT statements (asyncpg uses executemany for inserts)
-    assert mock_db_connection.executemany.call_count >= 2
+    # Verify DB calls now use COPY batches.
+    assert mock_db_connection.copy_records_to_table.call_count >= 2
     
     # Verify stats
     assert writer._states_written == 1
     assert writer._events_written == 1
+
+@pytest.mark.asyncio
+async def test_writer_flush_uses_copy_for_states_and_events(writer, mock_db_connection):
+    """Test that flush writes state/event batches via COPY."""
+    mock_db_connection.fetchval.return_value = 0
+
+    await writer.start()
+    await asyncio.sleep(0.1)
+
+    writer._entity_id_map["sensor.test"] = 1
+    now = datetime(2023, 10, 27, 10, 0, 0, tzinfo=timezone.utc)
+
+    writer.enqueue({"type": "state", "entity_id": "sensor.test", "time": now, "state": "on", "value": 1.0, "attributes": {"foo": "bar"}})
+    writer.enqueue({"type": "event", "time": now, "event_type": "test", "event_data": {"bar": 1}, "origin": "LOCAL"})
+
+    await writer._flush()
+
+    assert mock_db_connection.copy_records_to_table.call_count == 2
+    state_call = mock_db_connection.copy_records_to_table.call_args_list[0]
+    event_call = mock_db_connection.copy_records_to_table.call_args_list[1]
+
+    assert state_call.kwargs["table_name"] == "states_raw"
+    assert state_call.kwargs["columns"] == ["time", "metadata_id", "state", "value", "attributes"]
+    assert state_call.kwargs["records"][0][1] == 1
+
+    assert event_call.kwargs["table_name"] == writer.table_name_events
+    assert event_call.kwargs["columns"] == ["time", "event_type", "event_data", "origin", "context_id", "context_user_id", "context_parent_id"]
+    assert event_call.kwargs["records"][0][1] == "test"
+
 
 @pytest.mark.asyncio
 async def test_writer_no_buffer_on_failure(writer, mock_pool, mock_db_connection):
@@ -137,7 +165,7 @@ async def test_writer_no_buffer_on_failure(writer, mock_pool, mock_db_connection
     await writer.start()
     
     # Mock connection failure during flush
-    mock_db_connection.executemany.side_effect = Exception("Connection failed")
+    mock_db_connection.copy_records_to_table.side_effect = Exception("Connection failed")
     mock_db_connection.fetchval.side_effect = Exception("Connection failed")
     mock_db_connection.fetchrow.side_effect = Exception("Connection failed")
     
@@ -162,7 +190,7 @@ async def test_writer_buffer_on_failure(writer, mock_pool, mock_db_connection):
     await writer.start()
     
     # Mock connection failure during flush
-    mock_db_connection.executemany.side_effect = Exception("Connection failed")
+    mock_db_connection.copy_records_to_table.side_effect = Exception("Connection failed")
     mock_db_connection.fetchval.side_effect = Exception("Connection failed")
     mock_db_connection.fetchrow.side_effect = Exception("Connection failed")
     
@@ -414,8 +442,8 @@ async def test_writer_buffer_full_drop_oldest(writer, mock_pool, mock_db_connect
         
     acquire_ctx.__aenter__ = AsyncMock(side_effect=mock_enter)
     
-    # Mock executemany() to raise exception
-    mock_db_connection.executemany.side_effect = Exception("Flush Error")
+    # Mock COPY to raise exception
+    mock_db_connection.copy_records_to_table.side_effect = Exception("Flush Error")
     
     # Trigger flush manually
     await writer._flush()
@@ -494,13 +522,10 @@ async def test_writer_sanitizes_null_bytes(writer, mock_db_connection):
     # Trigger flush manually
     await writer._flush()
     
-    # Verify executemany call
-    assert mock_db_connection.executemany.called
-    # Get the latest call (it might have been called multiple times, e.g. for events if any)
-    # But here we only have one state
-    call_args = mock_db_connection.executemany.call_args_list[0]
-    # call_args[0] is (sql, args_list)
-    args_list = call_args[0][1]
+    # Verify COPY call
+    assert mock_db_connection.copy_records_to_table.called
+    call_args = mock_db_connection.copy_records_to_table.call_args_list[0]
+    args_list = call_args.kwargs["records"]
     
     # Verify the first item in the batch
     # Tuple: (time, metadata_id, state, value, attributes)
@@ -543,9 +568,9 @@ async def test_writer_sanitizes_infinity(writer, mock_db_connection):
     
     await writer._flush()
     
-    assert mock_db_connection.executemany.called
-    call_args = mock_db_connection.executemany.call_args_list[0]
-    args_list = call_args[0][1]
+    assert mock_db_connection.copy_records_to_table.called
+    call_args = mock_db_connection.copy_records_to_table.call_args_list[0]
+    args_list = call_args.kwargs["records"]
     # Tuple: (time, metadata_id, state, value, attributes)
     item_value = args_list[0][3]
     item_attributes_str = args_list[0][4]


### PR DESCRIPTION
Summary
- replace batched state and event writes with copy_records_to_table(...)
- keep the existing fallback path so writes can still fall back when COPY is not available
- update the writer tests and mocks for COPY-based batching

Why
Using PostgreSQL COPY for batched writes is more efficient than row-by-row batched inserts. It reduces per-row overhead and better supports direct compression on ingest, which can improve insert efficiency for TimescaleDB/columnstore workloads.

Validation
- pytest tests/test_writer.py -q
- verified previously on the live Home Assistant deployment with the updated Scribe build