### PR TITLE
fix(filter): exclude_entity_globs now overrides include_entity_globs (#33)

### DIFF
--- a/custom_components/scribe/__init__.py
+++ b/custom_components/scribe/__init__.py
@@ -124,6 +124,46 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+def _build_exclude_priority_filter(
+    base_filter,
+    exclude_entities,
+    exclude_entity_globs,
+):
+    """Wrap ``base_filter`` so an exclude-glob match always rejects.
+
+    Home Assistant's ``generate_filter`` (case 4a) short-circuits on
+    ``include_entity_globs`` — when an entity matches an include glob the
+    exclude globs are never checked. Scribe users expect the opposite:
+    ``exclude_entity_globs`` should be a hard reject regardless of what
+    the include configuration looks like.
+
+    The wrapper checks ``exclude_entities`` and ``exclude_entity_globs``
+    first; if either matches, the entity is rejected. Otherwise the call
+    falls through to the upstream filter, preserving all other
+    Home-Assistant filter semantics (domain include/exclude, the
+    no-filter pass-through, etc.).
+    """
+    import fnmatch
+
+    exclude_entities_set = set(exclude_entities or [])
+    glob_patterns = list(exclude_entity_globs or [])
+
+    if not exclude_entities_set and not glob_patterns:
+        return base_filter
+
+    def _excluded(entity_id: str) -> bool:
+        if entity_id in exclude_entities_set:
+            return True
+        return any(fnmatch.fnmatchcase(entity_id, pat) for pat in glob_patterns)
+
+    def _filter(entity_id: str) -> bool:
+        if _excluded(entity_id):
+            return False
+        return base_filter(entity_id)
+
+    return _filter
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Scribe component from YAML.
     
@@ -233,6 +273,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         exclude_domains,
         exclude_entities,
         include_entity_globs,
+        exclude_entity_globs,
+    )
+
+    # Home Assistant's `generate_filter` (case 4a) lets `include_entity_globs`
+    # short-circuit *over* `exclude_entity_globs`: when an entity matches an
+    # include glob, the exclude globs are never checked. Scribe users expect
+    # the opposite — `exclude_entity_globs` should override
+    # `include_entity_globs`, mirroring how `exclude_entities` already takes
+    # precedence over `include_entity_globs`.
+    #
+    # Wrap the filter so an exclude-glob match (or an exclude-entity match)
+    # is always a hard reject, then defer to the upstream filter for
+    # everything else. See https://github.com/jonathan-gtd/scribe/issues/33.
+    entity_filter = _build_exclude_priority_filter(
+        entity_filter,
+        exclude_entities,
         exclude_entity_globs,
     )
     

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -119,3 +119,55 @@ async def test_include_entity_globs(hass: HomeAssistant, mock_writer):
     })
     await hass.async_block_till_done()
     assert mock_writer.enqueue.call_count == 0
+
+
+async def test_exclude_entity_globs_overrides_include_entity_globs(hass: HomeAssistant, mock_writer):
+    """Regression for jonathan-gtd/scribe#33.
+
+    Home Assistant's ``generate_filter`` lets ``include_entity_globs`` short-
+    circuit over ``exclude_entity_globs`` (case 4a). Scribe wraps the
+    upstream filter so an exclude-glob match is always a hard reject —
+    matching the user-visible expectation that excludes win over includes.
+    """
+    config = {
+        DOMAIN: {
+            CONF_DB_URL: "postgresql://user:pass@localhost/db",
+            CONF_INCLUDE_ENTITY_GLOBS: ["sensor.*_temperature"],
+            CONF_EXCLUDE_ENTITY_GLOBS: ["sensor.processor_*"],
+        }
+    }
+
+    with patch("custom_components.scribe.ScribeWriter", return_value=mock_writer):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+
+    # Matches include_entity_globs only — should be recorded.
+    hass.bus.async_fire(EVENT_STATE_CHANGED, {
+        "entity_id": "sensor.living_room_temperature",
+        "new_state": Mock(state="22", attributes={})
+    })
+    await hass.async_block_till_done()
+    assert mock_writer.enqueue.call_count == 1
+    mock_writer.enqueue.reset_mock()
+
+    # Matches BOTH include_entity_globs (sensor.*_temperature) AND
+    # exclude_entity_globs (sensor.processor_*). Pre-fix, the upstream
+    # filter recorded this entity because the include glob short-
+    # circuited. Post-fix, the exclude glob wins.
+    hass.bus.async_fire(EVENT_STATE_CHANGED, {
+        "entity_id": "sensor.processor_temperature",
+        "new_state": Mock(state="62", attributes={})
+    })
+    await hass.async_block_till_done()
+    assert mock_writer.enqueue.call_count == 0, (
+        "sensor.processor_temperature must be excluded — exclude_entity_globs "
+        "should override include_entity_globs"
+    )
+
+    # Matches exclude_entity_globs only — must remain excluded.
+    hass.bus.async_fire(EVENT_STATE_CHANGED, {
+        "entity_id": "sensor.processor_use",
+        "new_state": Mock(state="42", attributes={})
+    })
+    await hass.async_block_till_done()
+    assert mock_writer.enqueue.call_count == 0


### PR DESCRIPTION
Closes #33.

## Reproduction (from the issue)
```yaml
include_entity_globs: [\"sensor.*_temperature\"]
exclude_entity_globs: [\"sensor.processor_*\"]
```
Expected: `sensor.processor_temperature` is excluded.
Actual: `sensor.processor_temperature` is still recorded.

## Root cause
Home Assistant's `generate_filter` (`homeassistant.helpers.entityfilter._generate_filter_from_sets_and_pattern_lists`, case 4a) lets `include_entity_globs` **short-circuit over** `exclude_entity_globs`:

```python
return entity_id in include_e or (
    entity_id not in exclude_e
    and (
        bool(include_eg and include_eg.match(entity_id))   # <-- include glob wins, exclude never checked
        or (
            split_entity_id(entity_id)[0] in include_d
            and not (exclude_eg and exclude_eg.match(entity_id))
        )
    )
)
```
So when both globs match, the include glob short-circuits to `True` and the exclude glob is never consulted. Scribe users — and the issue reporter — expect the opposite.

## Fix
Wrap the result of `generate_filter` with a small `_build_exclude_priority_filter` that:
1. checks `exclude_entities` and `exclude_entity_globs` first; on any match the entity is rejected,
2. otherwise defers to the upstream filter.

The wrapper preserves HA semantics for everything else (domain include/exclude, entity-level include, no-filter pass-through), and is a no-op when no excludes are configured (common-case fast path).

```python
entity_filter = generate_filter(...)
entity_filter = _build_exclude_priority_filter(entity_filter, exclude_entities, exclude_entity_globs)
```

## Test plan
Added `test_exclude_entity_globs_overrides_include_entity_globs` in `tests/test_filter.py` — the exact reproduction from the issue (`include: sensor.*_temperature`, `exclude: sensor.processor_*`):

- [x] `sensor.living_room_temperature` (include only) → recorded.
- [x] `sensor.processor_temperature` (matches both) → excluded (was: incorrectly recorded).
- [x] `sensor.processor_use` (exclude only) → excluded.

Local results:
- [x] `python3 -m ast` parses both modified files cleanly.
- [x] Standalone Python repro confirms the wrapper produces the documented behavior on simulated `generate_filter` output.
- [ ] Full pytest suite requires the home-assistant test harness which the repo bootstraps via `requirements_test.txt`; CI will run it.