### PR TITLE
BUG: enhance JSON encoder to handle UUID serialization in ScribeWriter

### DIFF
--- a/custom_components/scribe/writer.py
+++ b/custom_components/scribe/writer.py
@@ -16,6 +16,7 @@ from typing import Any, Dict
 from collections import deque
 import json
 import math
+import uuid
 
 import asyncpg
 
@@ -297,7 +298,7 @@ class ScribeWriter:
                     async def _init_connection(conn):
                         await conn.set_type_codec(
                             'jsonb',
-                            encoder=lambda x: b'\x01' + json.dumps(x, cls=JSONEncoder).encode('utf-8'),
+                            encoder=lambda x: b'\x01' + json.dumps(x, cls=JSONEncoder, default=lambda o: str(o) if isinstance(o, uuid.UUID) else JSONEncoder().default(o)).encode('utf-8'),
                             decoder=lambda x: json.loads(x[1:].decode('utf-8')),
                             schema='pg_catalog',
                             format='binary'


### PR DESCRIPTION
This pull request makes a targeted update to the JSON encoding logic for database connections in the `custom_components/scribe/writer.py` file. The main improvement is enhanced support for encoding UUID objects when storing JSONB data in PostgreSQL.

**Database encoding improvements:**

* Updated the JSON encoder for the PostgreSQL JSONB type to handle `uuid.UUID` objects by converting them to strings, ensuring compatibility when storing UUIDs in JSON fields.
* Added the `uuid` module import to support the new encoding logic.