### PR TITLE
fix(migration): robust preflight array parsing + restore postgres default

### DIFF
--- a/migration/preflight.py
+++ b/migration/preflight.py
@@ -35,11 +35,24 @@ def _table_exists(cur, table: str) -> bool:
     return cur.fetchone() is not None
 
 
+def _as_column_list(agg) -> list[str]:
+    """Normalize a Postgres ``array_agg`` result to a list of column names.
+
+    psycopg2 usually adapts a Postgres array to a Python ``list``, but on some
+    versions/platforms it returns the raw array literal (e.g. ``"{id,name}"``)
+    instead. Handle both so the preflight never fails on a schema that is
+    actually correct.
+    """
+    if isinstance(agg, str):
+        return [col.strip() for col in agg.strip("{}").split(",") if col.strip()]
+    return list(agg)
+
+
 def _unique_constraint_columns(cur, table: str) -> list[list[str]]:
     """Return one sorted column-list per PRIMARY KEY / UNIQUE constraint on `table`."""
     cur.execute(
         """
-        SELECT array_agg(kcu.column_name ORDER BY kcu.column_name) AS cols
+        SELECT array_agg(kcu.column_name::text ORDER BY kcu.column_name) AS cols
         FROM information_schema.table_constraints tc
         JOIN information_schema.key_column_usage kcu
           ON tc.constraint_name = kcu.constraint_name
@@ -50,7 +63,7 @@ def _unique_constraint_columns(cur, table: str) -> list[list[str]]:
         """,
         (table,),
     )
-    return [list(row[0]) for row in cur.fetchall()]
+    return [_as_column_list(row[0]) for row in cur.fetchall()]
 
 
 def preflight_scribe_schema(scribe_cur) -> None:

--- a/migration/recorder2scribe.py
+++ b/migration/recorder2scribe.py
@@ -49,7 +49,7 @@ def get_env_var(name, default=None, required=False):
     return val
 
 # Recorder
-RECORDER_TYPE = get_env_var("RECORDER_TYPE", "sqlite")
+RECORDER_TYPE = get_env_var("RECORDER_TYPE", "postgres")
 if RECORDER_TYPE == "sqlite":
     RECORDER_DB_PATH = get_env_var("RECORDER_DB_PATH", required=True)
 elif RECORDER_TYPE == "postgres":


### PR DESCRIPTION
## What

Two migration-script fixes.

### 1. Preflight schema check fails on a valid schema (fixes #41)

`migration/preflight.py` used `array_agg(kcu.column_name ...)` over
`information_schema`, which yields a `name[]` array. Its array typecaster
is **not registered by every psycopg2 build**, so on some platforms
`row[0]` came back as the raw literal `"{entity_id}"` instead of a Python
list. `list("{entity_id}")` then split it character-by-character, so the
`UNIQUE`/`PRIMARY KEY` check failed on a schema that was actually correct.

- Cast to `text[]` (`kcu.column_name::text`) so the result is reliably
  adapted to a list across psycopg2 versions/platforms.
- Add `_as_column_list()` to normalize both a `list` and a raw `"{...}"`
  string, so the preflight can never reject a valid schema again.

### 2. Restore `RECORDER_TYPE` default to `postgres`

The SQLite support merged in #42 defaulted `RECORDER_TYPE` to `sqlite`,
which silently broke existing PostgreSQL users who don't set the new env
var (and mismatched `.env.example`). Default restored to `postgres`.

## Test

`_as_column_list()` verified against the exact values reported in #41
(`{id}`, `{entity_id}`, `{metadata_id,time}`) plus the already-list case.

Closes #41