### PR TITLE
ci: add HACS + hassfest validation workflow

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,33 @@
+name: Validate
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  hacs:
+    name: HACS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration
+
+  hassfest:
+    name: Hassfest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Hassfest validation
+        uses: home-assistant/actions/hassfest@master

--- a/custom_components/scribe/icons.json
+++ b/custom_components/scribe/icons.json
@@ -1,0 +1,10 @@
+{
+    "services": {
+        "flush": {
+            "service": "mdi:database-arrow-right"
+        },
+        "query": {
+            "service": "mdi:database-search"
+        }
+    }
+}

--- a/custom_components/scribe/manifest.json
+++ b/custom_components/scribe/manifest.json
@@ -5,7 +5,6 @@
         "@jonathan-gtd"
     ],
     "config_flow": true,
-    "single_config_entry": true,
     "dependencies": [],
     "documentation": "https://github.com/jonathan-gtd/scribe",
     "integration_type": "service",
@@ -14,5 +13,6 @@
     "requirements": [
         "asyncpg>=0.28.0"
     ],
-    "version": "3.6.2"
+    "single_config_entry": true,
+    "version": "3.6.3"
 }

--- a/custom_components/scribe/services.yaml
+++ b/custom_components/scribe/services.yaml
@@ -1,12 +1,10 @@
 flush:
   name: Flush Buffer
   description: Manually flush the event buffer to the database.
-  icon: mdi:database-arrow-right
 
 query:
   name: Query Database
   description: Execute a read-only SQL query against the TimescaleDB database.
-  icon: mdi:database-search
   fields:
     sql:
       name: SQL Query
@@ -15,6 +13,3 @@ query:
       selector:
         text:
           multiline: true
-  response:
-    query_result:
-      description: A list of rows returned by the query.


### PR DESCRIPTION
Adds `.github/workflows/validate.yaml` running:

- **HACS** validation (`hacs/action@main`, `category: integration`)
- **hassfest** (`home-assistant/actions/hassfest`)

on push to master, pull requests, and daily. This is a prerequisite for
listing Scribe in the HACS default store.